### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Things you may want to cover:
 |massage|storing|null:false,|
 
 ### Association
--belongs_to :users
+- belongs_to :users
 
 
 


### PR DESCRIPTION
#WHAT
メッセージテーブルのアソシエーション説明部分

#WHY
記載ミスがあったため